### PR TITLE
Add legal pages and expand policy content

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -14,6 +14,11 @@ import Admin from "./pages/admin/Admin";
 import Auth from "./pages/auth/Auth";
 import About from "./pages/About";
 import Contact from "./pages/Contact";
+import Careers from "./pages/Careers";
+import ReturnPolicy from "./pages/ReturnPolicy";
+import RefundPolicy from "./pages/RefundPolicy";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
+import Disclaimer from "./pages/Disclaimer";
 import Layout from "@/components/layout/Layout";
 import ProductDetail from "./pages/products/ProductDetail";
 
@@ -35,6 +40,11 @@ const App = () => (
             <Route path="auth" element={<Auth />} />
             <Route path="about" element={<About />} />
             <Route path="contact" element={<Contact />} />
+            <Route path="careers" element={<Careers />} />
+            <Route path="return-policy" element={<ReturnPolicy />} />
+            <Route path="refund-policy" element={<RefundPolicy />} />
+            <Route path="privacy-policy" element={<PrivacyPolicy />} />
+            <Route path="disclaimer" element={<Disclaimer />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Route>

--- a/client/pages/Disclaimer.tsx
+++ b/client/pages/Disclaimer.tsx
@@ -14,8 +14,8 @@ export default function Disclaimer() {
         <p className="text-muted-foreground">
           We strive to describe products accurately; however, colors, materials,
           and specifications may vary slightly from the images shown. Packaging
-          may be updated by manufacturers without prior notice. Always review the
-          instructions included with your purchase before use.
+          may be updated by manufacturers without prior notice. Always review
+          the instructions included with your purchase before use.
         </p>
       </section>
 
@@ -34,8 +34,8 @@ export default function Disclaimer() {
         <h2 className="text-xl font-semibold">Third-Party Links</h2>
         <p className="text-muted-foreground">
           Our website may include links to third-party resources for your
-          convenience. AZORIX does not endorse or control the content on external
-          sites and is not responsible for losses caused by relying on
+          convenience. AZORIX does not endorse or control the content on
+          external sites and is not responsible for losses caused by relying on
           information found there.
         </p>
       </section>

--- a/client/pages/Disclaimer.tsx
+++ b/client/pages/Disclaimer.tsx
@@ -1,0 +1,70 @@
+export default function Disclaimer() {
+  return (
+    <section className="container py-12 max-w-3xl space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Disclaimer</h1>
+        <p className="text-muted-foreground">
+          This page outlines important notices about product information,
+          third-party content, and responsibility when shopping with AZORIX.
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Product Information</h2>
+        <p className="text-muted-foreground">
+          We strive to describe products accurately; however, colors, materials,
+          and specifications may vary slightly from the images shown. Packaging
+          may be updated by manufacturers without prior notice. Always review the
+          instructions included with your purchase before use.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Health &amp; Safety</h2>
+        <p className="text-muted-foreground">
+          Any wellness, beauty, or fitness products sold on our site are not
+          substitutes for professional medical advice. Consult a licensed
+          healthcare provider before starting new treatments or routines. AZORIX
+          is not liable for injuries or damages resulting from misuse of
+          products.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Third-Party Links</h2>
+        <p className="text-muted-foreground">
+          Our website may include links to third-party resources for your
+          convenience. AZORIX does not endorse or control the content on external
+          sites and is not responsible for losses caused by relying on
+          information found there.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Limitation of Liability</h2>
+        <p className="text-muted-foreground">
+          To the fullest extent permitted by law, AZORIX will not be liable for
+          indirect, incidental, or consequential damages arising from the use of
+          our products or website. Your sole remedy for dissatisfaction is to
+          discontinue use of the site or return the product in accordance with
+          our policies.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Contact Us</h2>
+        <p className="text-muted-foreground">
+          Questions about this disclaimer can be directed to
+          <a
+            href="mailto:legal@azorix.shop"
+            className="text-primary underline-offset-2 hover:underline"
+          >
+            legal@azorix.shop
+          </a>{" "}
+          or by mail at AZORIX Legal, 123 Market Street, Suite 400, Seattle, WA
+          98101.
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/client/pages/PrivacyPolicy.tsx
+++ b/client/pages/PrivacyPolicy.tsx
@@ -1,11 +1,88 @@
 export default function PrivacyPolicy() {
   return (
-    <section className="container py-12 max-w-3xl">
-      <h1 className="text-2xl font-bold">Privacy Policy</h1>
-      <p className="mt-3 text-muted-foreground">
-        We collect minimal personal data necessary to fulfill your orders and
-        improve our services. We never sell your data.
-      </p>
+    <section className="container py-12 max-w-3xl space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Privacy Policy</h1>
+        <p className="text-muted-foreground">
+          Protecting your personal information is a responsibility we take
+          seriously. This policy explains what data we collect, how it is used,
+          and the choices available to you.
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Information We Collect</h2>
+        <ul className="list-disc pl-5 space-y-2 text-muted-foreground">
+          <li>
+            <span className="font-medium">Account Details:</span> name, email,
+            password hash, and shipping address.
+          </li>
+          <li>
+            <span className="font-medium">Order Information:</span> products
+            purchased, payment method, and transaction IDs.
+          </li>
+          <li>
+            <span className="font-medium">Device Data:</span> IP address,
+            browser type, and anonymized analytics to improve site performance.
+          </li>
+        </ul>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">How We Use Your Data</h2>
+        <p className="text-muted-foreground">
+          Data is processed to fulfill orders, personalize recommendations,
+          deliver marketing communications (with your consent), and prevent
+          fraudulent activity. We do not sell or rent your personal data.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Sharing With Service Providers</h2>
+        <p className="text-muted-foreground">
+          We share information with trusted partners that help us run our
+          business, such as payment processors, shipping carriers, and analytics
+          providers. These partners are contractually required to safeguard your
+          data and use it only for agreed-upon purposes.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Your Rights &amp; Choices</h2>
+        <ul className="list-disc pl-5 space-y-2 text-muted-foreground">
+          <li>Update or correct your account information at any time.</li>
+          <li>Opt out of marketing emails by using the unsubscribe link.</li>
+          <li>
+            Request a copy or deletion of your personal data by contacting our
+            privacy team.
+          </li>
+        </ul>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Data Security</h2>
+        <p className="text-muted-foreground">
+          We employ encryption, access controls, and routine security audits to
+          protect your information. Despite our efforts, no method of
+          transmission over the internet is 100% secure, so please use strong
+          passwords and keep your credentials confidential.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Contact Us</h2>
+        <p className="text-muted-foreground">
+          For questions or requests regarding this policy, email
+          <a
+            href="mailto:privacy@azorix.shop"
+            className="text-primary underline-offset-2 hover:underline"
+          >
+            privacy@azorix.shop
+          </a>{" "}
+          or write to AZORIX Privacy Office, 123 Market Street, Suite 400,
+          Seattle, WA 98101.
+        </p>
+      </section>
     </section>
   );
 }

--- a/client/pages/PrivacyPolicy.tsx
+++ b/client/pages/PrivacyPolicy.tsx
@@ -38,7 +38,9 @@ export default function PrivacyPolicy() {
       </section>
 
       <section className="space-y-3">
-        <h2 className="text-xl font-semibold">Sharing With Service Providers</h2>
+        <h2 className="text-xl font-semibold">
+          Sharing With Service Providers
+        </h2>
         <p className="text-muted-foreground">
           We share information with trusted partners that help us run our
           business, such as payment processors, shipping carriers, and analytics

--- a/client/pages/RefundPolicy.tsx
+++ b/client/pages/RefundPolicy.tsx
@@ -22,28 +22,28 @@ export default function RefundPolicy() {
       <section className="space-y-3">
         <h2 className="text-xl font-semibold">Processing Timeline</h2>
         <p className="text-muted-foreground">
-          Once we receive your returned item, please allow <strong>2–3 business
-          days</strong> for inspection. After approval, most banks post credits
-          within <strong>5–7 business days</strong>. We will email you as soon as
-          the refund is released.
+          Once we receive your returned item, please allow{" "}
+          <strong>2–3 business days</strong> for inspection. After approval,
+          most banks post credits within <strong>5–7 business days</strong>. We
+          will email you as soon as the refund is released.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl font-semibold">Partial Refunds</h2>
         <p className="text-muted-foreground">
-          We reserve the right to issue partial refunds for items that show signs
-          of use, are missing accessories, or are returned outside the stated
-          window. You will be notified of any adjustment before the refund is
-          finalized.
+          We reserve the right to issue partial refunds for items that show
+          signs of use, are missing accessories, or are returned outside the
+          stated window. You will be notified of any adjustment before the
+          refund is finalized.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl font-semibold">Shipping Fees</h2>
         <p className="text-muted-foreground">
-          Outbound shipping fees are non-refundable unless the return is due to a
-          shipping error or a defective item. If you opted for expedited
+          Outbound shipping fees are non-refundable unless the return is due to
+          a shipping error or a defective item. If you opted for expedited
           delivery, the service charge will not be reimbursed.
         </p>
       </section>

--- a/client/pages/RefundPolicy.tsx
+++ b/client/pages/RefundPolicy.tsx
@@ -1,11 +1,76 @@
 export default function RefundPolicy() {
   return (
-    <section className="container py-12 max-w-3xl">
-      <h1 className="text-2xl font-bold">Refund Policy</h1>
-      <p className="mt-3 text-muted-foreground">
-        Refunds are processed to the original payment method after the returned
-        item is inspected. Processing may take 5–7 business days.
-      </p>
+    <section className="container py-12 max-w-3xl space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Refund Policy</h1>
+        <p className="text-muted-foreground">
+          We aim to process refunds quickly so you can shop with confidence. The
+          information below explains how we handle refunds for returns,
+          cancellations, and order issues.
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Refund Methods</h2>
+        <p className="text-muted-foreground">
+          Approved refunds are issued to the original payment method. For
+          buy-now-pay-later services, your provider will adjust the payment
+          schedule according to their policies.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Processing Timeline</h2>
+        <p className="text-muted-foreground">
+          Once we receive your returned item, please allow <strong>2–3 business
+          days</strong> for inspection. After approval, most banks post credits
+          within <strong>5–7 business days</strong>. We will email you as soon as
+          the refund is released.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Partial Refunds</h2>
+        <p className="text-muted-foreground">
+          We reserve the right to issue partial refunds for items that show signs
+          of use, are missing accessories, or are returned outside the stated
+          window. You will be notified of any adjustment before the refund is
+          finalized.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Shipping Fees</h2>
+        <p className="text-muted-foreground">
+          Outbound shipping fees are non-refundable unless the return is due to a
+          shipping error or a defective item. If you opted for expedited
+          delivery, the service charge will not be reimbursed.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Order Cancellations</h2>
+        <p className="text-muted-foreground">
+          Orders can be cancelled within <strong>60 minutes</strong> of purchase
+          from the order confirmation screen. After this window, please follow
+          our standard return process to request a refund once the item arrives.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Still Need Help?</h2>
+        <p className="text-muted-foreground">
+          Contact our support team at
+          <a
+            href="mailto:billing@azorix.shop"
+            className="text-primary underline-offset-2 hover:underline"
+          >
+            billing@azorix.shop
+          </a>{" "}
+          or call <span className="font-medium">(800) 123-4567</span> if your
+          refund has not appeared after the estimated timeframe.
+        </p>
+      </section>
     </section>
   );
 }

--- a/client/pages/ReturnPolicy.tsx
+++ b/client/pages/ReturnPolicy.tsx
@@ -29,7 +29,9 @@ export default function ReturnPolicy() {
             Print the prepaid return label we provide and securely pack your
             item.
           </li>
-          <li>Drop the package at any carrier location indicated on the label.</li>
+          <li>
+            Drop the package at any carrier location indicated on the label.
+          </li>
         </ol>
         <p className="text-sm text-muted-foreground/80">
           If you checked out as a guest, contact our support team with your
@@ -40,7 +42,9 @@ export default function ReturnPolicy() {
       <section className="space-y-3">
         <h2 className="text-xl font-semibold">Non-Returnable Items</h2>
         <ul className="list-disc pl-5 space-y-2 text-muted-foreground">
-          <li>Final sale or clearance items clearly marked as non-returnable.</li>
+          <li>
+            Final sale or clearance items clearly marked as non-returnable.
+          </li>
           <li>Gift cards, downloadable software, or perishable goods.</li>
           <li>
             Items damaged through improper use or missing essential components.
@@ -68,8 +72,8 @@ export default function ReturnPolicy() {
           >
             support@azorix.shop
           </a>{" "}
-          or call <span className="font-medium">(800) 123-4567</span> for real-time
-          guidance.
+          or call <span className="font-medium">(800) 123-4567</span> for
+          real-time guidance.
         </p>
       </section>
     </section>

--- a/client/pages/ReturnPolicy.tsx
+++ b/client/pages/ReturnPolicy.tsx
@@ -1,11 +1,77 @@
 export default function ReturnPolicy() {
   return (
-    <section className="container py-12 max-w-3xl">
-      <h1 className="text-2xl font-bold">Return Policy</h1>
-      <p className="mt-3 text-muted-foreground">
-        Returns are accepted within 30 days of delivery for items in original
-        condition. Keep the packaging and proof of purchase.
-      </p>
+    <section className="container py-12 max-w-3xl space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Return Policy</h1>
+        <p className="text-muted-foreground">
+          We want you to be thrilled with your purchase. If something is not
+          quite right, review the details below to understand how to start a
+          hassle-free return.
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Eligibility Window</h2>
+        <p className="text-muted-foreground">
+          Returns are accepted within <strong>30 days</strong> of the delivery
+          date. Items must be unused, unwashed, and in their original packaging
+          with all tags attached. For bundled items, all components must be
+          returned together.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">How to Start a Return</h2>
+        <ol className="list-decimal pl-5 space-y-2 text-muted-foreground">
+          <li>Log in to your account and visit the Orders section.</li>
+          <li>Select the item you would like to return and choose a reason.</li>
+          <li>
+            Print the prepaid return label we provide and securely pack your
+            item.
+          </li>
+          <li>Drop the package at any carrier location indicated on the label.</li>
+        </ol>
+        <p className="text-sm text-muted-foreground/80">
+          If you checked out as a guest, contact our support team with your
+          order number to receive a return label.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Non-Returnable Items</h2>
+        <ul className="list-disc pl-5 space-y-2 text-muted-foreground">
+          <li>Final sale or clearance items clearly marked as non-returnable.</li>
+          <li>Gift cards, downloadable software, or perishable goods.</li>
+          <li>
+            Items damaged through improper use or missing essential components.
+          </li>
+        </ul>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Return Shipping</h2>
+        <p className="text-muted-foreground">
+          Domestic returns using our prepaid label are free. If you choose a
+          different shipping method, shipping fees are non-refundable. For
+          international orders, return shipping charges are the responsibility
+          of the customer unless the item was received defective or incorrect.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Need Assistance?</h2>
+        <p className="text-muted-foreground">
+          Our customer care team is available seven days a week. Reach us at
+          <a
+            href="mailto:support@azorix.shop"
+            className="text-primary underline-offset-2 hover:underline"
+          >
+            support@azorix.shop
+          </a>{" "}
+          or call <span className="font-medium">(800) 123-4567</span> for real-time
+          guidance.
+        </p>
+      </section>
     </section>
   );
 }


### PR DESCRIPTION
## Changes Made

### New Pages Added
- **Careers** - New page component and route at `/careers`
- **Disclaimer** - New page component and route at `/disclaimer`

### Enhanced Policy Pages
- **Privacy Policy** - Expanded from basic content to comprehensive policy with sections covering:
  - Information collection details
  - Data usage and sharing practices
  - User rights and choices
  - Security measures
  - Contact information

- **Return Policy** - Enhanced from simple description to detailed policy including:
  - 30-day eligibility window
  - Step-by-step return process
  - Non-returnable items list
  - Shipping information
  - Customer support details

- **Refund Policy** - Expanded from basic info to complete policy covering:
  - Refund methods and processing timeline
  - Partial refund conditions
  - Shipping fee policies
  - Order cancellation rules
  - Support contact information

### Routing Updates
- Added 5 new routes in `App.tsx` for the new and existing policy pages
- All routes follow consistent URL patterns with kebab-case naming

### UI Improvements
- Consistent styling across all policy pages using Tailwind classes
- Improved typography with proper heading hierarchy
- Better content organization with clear sections
- Professional formatting with proper spacing and layout

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2ebb397b2ef64ad99a464247abbf4eda/neon-home)

👀 [Preview Link](https://2ebb397b2ef64ad99a464247abbf4eda-neon-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2ebb397b2ef64ad99a464247abbf4eda</projectId>-->
<!--<branchName>neon-home</branchName>-->